### PR TITLE
Add in mp_match_restart_delay to cvars.txt

### DIFF
--- a/CVARS.txt
+++ b/CVARS.txt
@@ -15,6 +15,7 @@ mp_limitteams 0
 mp_warmuptime 0
 mp_freezetime 1
 mp_maxrounds 10
+mp_match_restart_delay 5
 mp_roundtime 5
 mp_timelimit 30
 mp_teammates_are_enemies 1


### PR DESCRIPTION
Current defaults means staying on the leaderboard for 20 seconds at the end of each ten rounds.  Especially due to the fact that kills, assists and deaths aren't recorded this means you just wait for that time.