### PR TITLE
Fix for players not earning credits every minute.

### DIFF
--- a/addons/sourcemod/scripting/ttt/ttt_shop.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_shop.sp
@@ -545,7 +545,7 @@ public void TTT_OnClientGetRole(int client, int role)
 {
 	if (g_bCreditsTimer)
 	{
-		if (g_fCreditsInterval > 60.0)
+		if (g_fCreditsInterval >= 60.0)
 		{
 			g_hCreditsTimer[client] = CreateTimer(g_fCreditsInterval, Timer_CreditsTimer, GetClientUserId(client), TIMER_REPEAT | TIMER_FLAG_NO_MAPCHANGE);
 		}


### PR DESCRIPTION
Fix for ttt_credits_timer not taking effect when ttt_credits_interval is at 60 seconds.