### PR TITLE
Fix "Invalid timer handle" for g_hCreditsTimer.

### DIFF
--- a/addons/sourcemod/scripting/ttt/ttt_shop.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_shop.sp
@@ -616,6 +616,7 @@ public Action Event_PlayerDeathPre(Event event, const char[] menu, bool dontBroa
 
 public void OnClientDisconnect(int client)
 {
+	g_hCreditsTimer[client] = null;
 	ClearTimer(g_hCreditsTimer[client]);
 }
 
@@ -688,6 +689,7 @@ public void TTT_OnRoundEnd(int WinningTeam)
 {
 	LoopValidClients(client)
 	{
+		g_hCreditsTimer[client] = null;
 		ClearTimer(g_hCreditsTimer[client]);
 		switch (WinningTeam)
 		{


### PR DESCRIPTION
The following errors spew without this fix. I believe the edge-case is it tries to clear the timer when a player disconnects, or when the round ends, **before** the timer is run again for it to set itself to null for being dead. I am not sure if this is the best way, but it does work (tested).

L 06/21/2017 - 09:10:44: [SM] Exception reported: Invalid timer handle 2559029c (error 3)
L 06/21/2017 - 09:10:44: [SM] Blaming: cs-ttt\ttt_shop.smx
L 06/21/2017 - 09:10:44: [SM] Call stack trace:
L 06/21/2017 - 09:10:44: [SM]   [0] KillTimer
L 06/21/2017 - 09:10:44: [SM]   [1] Line 765, ttt_shop.sp::ClearTimer
L 06/21/2017 - 09:10:44: [SM]   [2] Line 560, ttt_shop.sp::TTT_OnRoundEnd
L 06/21/2017 - 09:10:44: [SM]   [4] Call_Finish
L 06/21/2017 - 09:10:44: [SM]   [5] Line 1948, C:\addons\sourcemod\scripting\ttt.sp::CS_OnTerminateRound
L 06/21/2017 - 09:10:44: [SM]   [7] CS_TerminateRound
L 06/21/2017 - 09:10:44: [SM]   [8] Line 2813, C:\addons\sourcemod\scripting\ttt.sp::CheckTeams
L 06/21/2017 - 09:10:44: [SM]   [9] Line 1868, C:\addons\sourcemod\scripting\ttt.sp::Event_PlayerDeath

L 06/21/2017 - 09:13:39: [SM] Exception reported: Invalid timer handle 93d3029b (error 1)
L 06/21/2017 - 09:13:39: [SM] Blaming: cs-ttt\ttt_shop.smx
L 06/21/2017 - 09:13:39: [SM] Call stack trace:
L 06/21/2017 - 09:13:39: [SM]   [0] KillTimer
L 06/21/2017 - 09:13:39: [SM]   [1] Line 765, ttt_shop.sp::ClearTimer
L 06/21/2017 - 09:13:39: [SM]   [2] Line 512, ttt_shop.sp::OnClientDisconnect