### PR TITLE
Fix for credits timer not repeating.

### DIFF
--- a/addons/sourcemod/scripting/ttt/ttt_shop.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_shop.sp
@@ -562,6 +562,7 @@ public Action Timer_CreditsTimer(Handle timer, any userid)
 		{
 			int iCredits = GetRandomInt(g_iCreditsMin, g_iCreditsMax);
 			addCredits(client, iCredits, g_bCreditsMessage);
+			return Plugin_Continue;
 		}
 	}
 	


### PR DESCRIPTION
Ensures the credits timer is repeats for as long as the player is valid and alive.