### PR TITLE
Logs dead only fix and feature

### DIFF
--- a/addons/sourcemod/scripting/include/ttt.inc
+++ b/addons/sourcemod/scripting/include/ttt.inc
@@ -66,6 +66,7 @@ enum eConfig
 	String:s_kickImmunity[16],
 	String:s_logsAccess[16],
 	bool:bLogsDeadOnly,
+	bool:bLogsNotifyAlive,
 	bool:b_updateClientModel, 
 	bool:b_removeHostages, 
 	bool:b_removeBomb, 

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -247,7 +247,8 @@ void SetupConfig()
 	g_iConfig[i_punishDetectiveKills] = Config_LoadInt("ttt_punish_detective_for_rdm_kils", 5, "The amount of times an detective will be allowed to kill another innocent/detective before being punished for RDM.");
 	Config_LoadString("ttt_kick_immunity", "bz", "Admin flags that won't be kicked for not reading the rules.", g_iConfig[s_kickImmunity], sizeof(g_iConfig[s_kickImmunity]));
 	Config_LoadString("ttt_logs_access", "bz", "Admin flags to view logs in a round.", g_iConfig[s_logsAccess], sizeof(g_iConfig[s_logsAccess]));
-	Config_LoadBool("ttt_logs_dead_only", false, "Access to logs only for dead admins?");
+	g_iConfig[bLogsDeadOnly] = Config_LoadBool("ttt_logs_dead_only", false, "Access to logs only for dead admins?");
+	g_iConfig[bLogsNotifyAlive] = Config_LoadBool("ttt_logs_notify_alive", true, "Notify if logs has been watched by alive admin");
 	g_iConfig[b_updateClientModel] = Config_LoadBool("ttt_update_client_model", true, "Update the client model isntantly when they are assigned a role. Disables forcing client models to a specified model. 1 = Update, 0 = Don't Update");
 	g_iConfig[b_removeHostages] = Config_LoadBool("ttt_remove_hostages", true, "Remove all hostages from the map to prevent interference. 1 = Remove, 0 = Don't Remove");
 	g_iConfig[b_removeBomb] = Config_LoadBool("ttt_remove_bomb_on_spawn", true, "Remove the bomb spots from the map to prevent interference. 1 = Remove, 0 = Don't Remove");
@@ -348,6 +349,11 @@ public Action Command_Logs(int client, int args)
 			else
 			{
 				ShowLogs(client);
+				if (g_iConfig[bLogsNotifyAlive])
+				{
+					LoopValidClients(j)
+						CPrintToChat(j, g_iConfig[s_pluginTag], "watching logs alive", j, client);
+				}
 			}
 		}	
 		return Plugin_Continue;

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -342,9 +342,10 @@ public Action Command_Logs(int client, int args)
 		}
 		else if (TTT_IsClientValid(client) && TTT_HasFlags(client, aFlags))
 		{
-			if (g_iConfig[bLogsDeadOnly] && !IsPlayerAlive(client))
+			if (g_iConfig[bLogsDeadOnly])
 			{
-				ShowLogs(client);
+				if (!IsPlayerAlive(client))
+					ShowLogs(client);
 			}
 			else
 			{

--- a/addons/sourcemod/translations/ttt.phrases.txt
+++ b/addons/sourcemod/translations/ttt.phrases.txt
@@ -321,6 +321,12 @@
 	{
 		"en"		"You can´t see the logs now, you need be dead or round has to be inactive"
 	}
+	
+	"watching logs alive"
+	{
+		"#format"	"{1:N}"
+		"en"		"{green}{1} {default}is {red}alive {default}and watching logs of current round."
+	}
 
 	"Receiving logs"
 	{


### PR DESCRIPTION
Added g_iConfig[bLogsDeadOnly] initialization on cvars read.
Added g_iConfig[bLogsNotifyAlive] to notify all players when someone is alive and using logs of current round.
Added phrase "watching logs alive" to translations.