### PR TITLE
Use correct color for "watching logs alive" phrase

### DIFF
--- a/addons/sourcemod/translations/ttt.phrases.txt
+++ b/addons/sourcemod/translations/ttt.phrases.txt
@@ -307,7 +307,7 @@
 	"watching logs alive"
 	{
 		"#format"	"{1:N}"
-		"en"		"{green}{1} {default}is {red}alive {default}and watching logs of current round."
+		"en"		"{green}{1} {default}is {darkred}alive {default}and watching logs of current round."
 	}
 
 	"Receiving logs"


### PR DESCRIPTION
Use correct color for "watching logs alive" phrase to resolve the following error:

[SM] Exception reported: Using two team colors in one message is not allowed