### PR TITLE
Resolve issue with shop items not purchasing

### DIFF
--- a/addons/sourcemod/scripting/ttt/ttt_shop.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_shop.sp
@@ -392,8 +392,8 @@ bool ClientBuyItem(int client, char[] item)
 			Action result = Plugin_Continue;
 			Call_StartForward(g_hOnItemPurchase);
 			Call_PushCell(client);
-			Call_PushCellRef(price);
-			Call_PushCellRef(count);
+			Call_PushCell(price);
+			Call_PushCell(count);
 			Call_PushString(temp_item[Short]);
 			Call_Finish(result);
 			


### PR DESCRIPTION
Resolve issue with shop items not purchasing due to the error below.

L 07/01/2017 - 13:34:09: [SM] Exception reported: Invalid parameter or parameter type
L 07/01/2017 - 13:34:09: [SM] Blaming: cs-ttt\ttt_shop.smx
L 07/01/2017 - 13:34:09: [SM] Call stack trace:
L 07/01/2017 - 13:34:09: [SM]   [0] Call_PushCellRef
L 07/01/2017 - 13:34:09: [SM]   [1] Line 395, ttt_shop.sp::ClientBuyItem
L 07/01/2017 - 13:34:09: [SM]   [2] Line 367, ttt_shop.sp::Menu_ShopHandler