### PR TITLE
Add missing language phrase "Item bought! (NEW)"

### DIFF
--- a/addons/sourcemod/translations/ttt.phrases.txt
+++ b/addons/sourcemod/translations/ttt.phrases.txt
@@ -165,10 +165,10 @@
 		"en"		"Please wait till your team is assigned"
 	}
 
-	"Item bought! Your REAL money is"
+	"Item bought! (NEW)"
 	{
 		"#format"	"{1:i},{2:s}"
-		"en"		"Item {2} bought! Your CREDITS are {1}"
+		"en"		"Item {2} bought for {3} credits! Remaining Credits: {1}"
 	}
 
 	"You don't have enough money"


### PR DESCRIPTION
L 07/01/2017 - 14:39:11: [SM] Exception reported: Language phrase "Item bought! (NEW)" not found (arg 5)
L 07/01/2017 - 14:39:11: [SM] Blaming: cs-ttt\ttt_shop.smx

This was originally added here https://github.com/Bara20/TroubleinTerroristTown/commit/fb6c28e69ecc554b1e766d55e87cf545558f7afe, but I assume accidentally removed here: https://github.com/Bara20/TroubleinTerroristTown/commit/88c370395be1ce76dd94e8c2e649a01719361b14