### PR TITLE
Prevents watching logs notification in pre-round

### DIFF
--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -350,7 +350,7 @@ public Action Command_Logs(int client, int args)
 			else
 			{
 				ShowLogs(client);
-				if (g_iConfig[bLogsNotifyAlive] > 0 && IsPlayerAlive(client))
+				if (g_iConfig[bLogsNotifyAlive] > 0 && !g_bRoundEnding && IsPlayerAlive(client))
 				{
 					if (g_iConfig[bLogsNotifyAlive] == 1)
 					{


### PR DESCRIPTION
It's irrelevant to know if an admin is watching logs whilst alive during a pre-round since the logs are for the previous round (which everyone has access to).