### PR TITLE
Detective fixes

### DIFF
--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -1170,6 +1170,9 @@ stock void TeamInitialize(int client)
 		if (GetPlayerWeaponSlot(client, CS_SLOT_PRIMARY) == -1)
 		{
 			GivePlayerItem(client, g_iConfig[sdefaultPriD]);
+		} else {
+			SDKHooks_DropWeapon(client, GetPlayerWeaponSlot(client, CS_SLOT_PRIMARY));
+			GivePlayerItem(client, g_iConfig[sdefaultPriD]);
 		}
 
 		CPrintToChat(client, g_iConfig[spluginTag], "Your Team is DETECTIVES", client);


### PR DESCRIPTION
If the chosen detective has a primary, his current primary is dropped for the M4A1-S. While the item could be dropped instead of dropping their current primary, I believe dropping their current weapon stops non-detectives from getting the a1 on maps without natural spawns.